### PR TITLE
Cw 282 support username for bootstrap script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 before_install:
- - 'cd bin && ./maven-install-custom.sh'
+ - 'cd bin && ./maven-install-custom.sh && cd ..'
 jdk:
  - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+before_install:
+ - 'cd bin && ./maven-install-custom.sh'
+jdk:
+ - openjdk6

--- a/cloudify-widget-hp/README.md
+++ b/cloudify-widget-hp/README.md
@@ -46,7 +46,8 @@
             "description" : "", 
             "securityGroup": "default", 
             "networkUuid": "__networkUuid__", 
-            "keyPairName": "__keyPairName__" 
+            "keyPairName": "__keyPairName__",
+            "username" : "__image_default_username_for_ssh_purposes__"
         } 
     }
 }

--- a/cloudify-widget-hp/src/main/java/cloudify/widget/hp/HpGrizzlyCloudServerApi.java
+++ b/cloudify-widget-hp/src/main/java/cloudify/widget/hp/HpGrizzlyCloudServerApi.java
@@ -260,7 +260,7 @@ public class HpGrizzlyCloudServerApi implements CloudServerApi<CloudServerPojo, 
         String privateKey = sshDetails.getPrivateKey();
         int port = sshDetails.getPort();
 
-        logger.debug("Run ssh on server: {} script: {}" , serverIp, script );
+        logger.debug("Run ssh on server: {} script: {} with username: {}" , serverIp, script, user );
         SshClient.Factory factory = computeServiceContext.getUtils().getSshClientFactory();
         LoginCredentials loginCredentials = LoginCredentials.builder().user(user).privateKey(privateKey).build();
         SshClient sshConnection = factory.create(HostAndPort.fromParts(serverIp, port),
@@ -524,6 +524,7 @@ public class HpGrizzlyCloudServerApi implements CloudServerApi<CloudServerPojo, 
             // if here, we have a node with a private and public ip.
             final OpenstackNode node = this.getNode(serverId, token);
 
+
             if (node.getPublicIp() == null) {
                 String floatingIp = allocateFloatingIP(token);
                 logger.info("create floating IP [{}]", floatingIp );
@@ -537,7 +538,7 @@ public class HpGrizzlyCloudServerApi implements CloudServerApi<CloudServerPojo, 
 
             md.setPublicAddress(node.getPublicIp());
             md.setMachineId(serverId);
-            md.setRemoteUsername("root");
+            md.setRemoteUsername(machineOptions.getUsername());
 
             return md;
         } catch (final Exception e) {

--- a/cloudify-widget-hp/src/main/java/cloudify/widget/hp/HpMachineOptions.java
+++ b/cloudify-widget-hp/src/main/java/cloudify/widget/hp/HpMachineOptions.java
@@ -15,6 +15,7 @@ public class HpMachineOptions implements MachineOptions {
     private String securityGroup = null;
     private String networkUuid;
     private String keyPairName;
+    private String username = "root"; // the username used to connect to this machine (not specified by openstack by default unfortunately.)
 
     public HpMachineOptions(){}
 
@@ -49,6 +50,14 @@ public class HpMachineOptions implements MachineOptions {
 
     public String getMask() {
         return mask;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
     }
 
     public int getMachinesCount() {

--- a/cloudify-widget-pool-manager/src/main/java/cloudify/widget/pool/manager/tasks/TaskRegistrar.java
+++ b/cloudify-widget-pool-manager/src/main/java/cloudify/widget/pool/manager/tasks/TaskRegistrar.java
@@ -6,6 +6,7 @@ import cloudify.widget.pool.manager.ErrorsDao;
 import cloudify.widget.pool.manager.ITasksDao;
 import cloudify.widget.pool.manager.dto.*;
 import com.google.common.collect.Maps;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,7 +165,7 @@ public class TaskRegistrar {
         @Override
         protected void registerError(Throwable thrown) {
             HashMap<String, Object> infoMap = Maps.newHashMap();
-            infoMap.put("stackTrace", thrown.getStackTrace());
+            infoMap.put("stackTrace", ExceptionUtils.getStackTrace(thrown));
             ErrorModel errorModel = new ErrorModel()
                     .setSource(_taskName.name())
                     .setMessage(thrown.getMessage())


### PR DESCRIPTION
Had to add this for cloudify3 pool. 

now, users can define `{ "machineOptions" : { "username" : "ubuntu" } }` and the bootstrap script will run as ubuntu..

Also improved error message when task fails. was driving me crazy.. 
